### PR TITLE
Update bioc.c: You had the output using `bioc_std.h` but your header is `bioc_stdlib.h`

### DIFF
--- a/bioc.c
+++ b/bioc.c
@@ -79,7 +79,7 @@ int main(int argc, char **argv) {
     fprintf(out, "#include <stdlib.h>\n");
     fprintf(out, "#include <string.h>\n");
     fprintf(out, "#include <stdbool.h>\n");
-    fprintf(out, "#include \"bioc_std.h\"\n\n");
+    fprintf(out, "#include \"bioc_stdlib.h\"\n\n");
 
     fprintf(out, "/* --- BioC transpiled code --- */\n\n");
 
@@ -273,3 +273,4 @@ int main(int argc, char **argv) {
     fclose(out);
     return 0;
 }
+


### PR DESCRIPTION
after transpiling the test, `test.bio`, there and using GCC the `out.c` file wouldn't compile, but now it does, there is still the problem of the `out.c` when compiled seg-faulting

```
 ~/Bio-C-vBeta main ? ./bioc test.bio    
~/Bio-C-vBeta main ? gcc out.c 
 ~/Bio-C-vBeta main ? ./a.out  
10
20
basic printing works
zsh: segmentation fault (core dumped)  ./a.out
```

this is because of your `bioc_stdlib.h` where in `lower` `strip` and `upper` when calling then you try to write to the string literal passes in, but string literals live in read only memory so when you try to write to them it failes, I did not resolve the segfault in this pr only the translation issue. 